### PR TITLE
Switch to non-obsoleted method to get ModelsBuilder path

### DIFF
--- a/src/ModelsBuilder.PropertyOverride/ModelsBuilder.PropertyOverride.csproj
+++ b/src/ModelsBuilder.PropertyOverride/ModelsBuilder.PropertyOverride.csproj
@@ -12,7 +12,7 @@
     <PackageTags>umbraco;umbraco-marketplace</PackageTags>
     <RootNamespace>Umbraco.Community.ModelsBuilder.PropertyOverride</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>15.0.0</Version>
+    <Version>15.0.1</Version>
     <Authors>Gibe Digital</Authors>
     <Copyright>$([System.DateTime]::UtcNow.ToString(`yyyy`)) © Gibe Digital</Copyright>
     <PackageProjectUrl>https://github.com/Gibe/Umbraco.Community.ModelsBuilder.PropertyOverride</PackageProjectUrl>

--- a/src/ModelsBuilder.PropertyOverride/PropertyOverrideModelsGenerator.cs
+++ b/src/ModelsBuilder.PropertyOverride/PropertyOverrideModelsGenerator.cs
@@ -2,25 +2,24 @@ using System.CodeDom.Compiler;
 using System.Reflection;
 using System.Text;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Infrastructure.ModelsBuilder;
 using Umbraco.Cms.Infrastructure.ModelsBuilder.Building;
-using Umbraco.Extensions;
 using File = System.IO.File;
 
 namespace Umbraco.Community.ModelsBuilder.PropertyOverride
 {
     public class PropertyOverrideModelsGenerator : IModelsGenerator
     {
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IHostEnvironment _hostingEnvironment;
         private readonly OutOfDateModelsStatus _outOfDateModels;
         private readonly UmbracoServices _umbracoService;
         private ModelsBuilderSettings _config;
         public PropertyOverrideModelsGenerator(UmbracoServices umbracoService,
             IOptionsMonitor<ModelsBuilderSettings> config,
             OutOfDateModelsStatus outOfDateModels,
-            IHostingEnvironment hostingEnvironment)
+            IHostEnvironment hostingEnvironment)
         {
             _umbracoService = umbracoService;
             _config = config.CurrentValue;


### PR DESCRIPTION
## Description

Umbraco 16 got rid of an obsoleted method that we were using.  This switches to the non-obsoleted method.

### Checklist

Please confirm each item before assigning people to this PR. 

- [x] I have checked for any issues with whitespace and code formatting.
- [x] I have checked that my code complies with our code standards [as documented](https://gibedigital.getoutline.com/doc/coding-standards-tWNxsvJIhK).
- [x] I have checked that the TeamCity build for this branch succeeds.
- [x] I have selected an appropriate base branch for this PR to be set against for comparison purposes. I.e. I have selected the branch on which this work is based.
- [x] If appropriate, I have updated the gherkins on this branch 